### PR TITLE
Make date-picker controlled

### DIFF
--- a/packages/reactJewishDatePicker/src/reactJewishDatePicker.tsx
+++ b/packages/reactJewishDatePicker/src/reactJewishDatePicker.tsx
@@ -63,6 +63,10 @@ export const ReactJewishDatePicker: React.FC<ReactJewishDatePickerProps> = (prop
     const endDateInit = isDateRange(value) && getDateInit(value.endDate);
 
     const [date, setDate] = React.useState(dateInit);
+    //If value prop changes, update internal date
+    useEffect(()=>{
+        setDate(value ? getDateInit(value) : new Date());
+    },[value])
     const jewishMonth = getJewishMonth(date);
 
     const [selectedDay, setSelectedDay] = React.useState<BasicJewishDay>(!isRange && value && jewishMonth.selectedDay);


### PR DESCRIPTION
Right now this library only supports Hebrew dates - I want to give my users an option of choosing a date via a gregorian calendar as well. To keep it simple I am using two date pickers side by side and want the selection on one to update the other. The issue is that your value prop is really a defaultValue prop, and doesnt allow controlling the value from the outside. Hence this change to make the calendar a controlled component. Thanks for sharing such a useful component.